### PR TITLE
class handlers are instantiated per call

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ command_bus.register(FooCommand, -> (foo_cmd) { FooService.new(event_store: even
 command_bus.register(BarCommand, -> (bar_cmd) { BarService.new.call(bar_cmd) })
 ```
 
+Alternatively, you can register a Class and it will be instantiated per call, which provides the same behavior as `subscribe` in RailsEventStore.
+
+```ruby
+command_bus = Arkency::CommandBus.new
+command_bus.register(FooCommand, -> FooService)
+command_bus.register(BarCommand, -> BarService)
+```
+
 ### Working with Rails development mode
 
 In Rails `development` mode when you change a registered class, it is reloaded, and a new class with same name is constructed. 

--- a/README.md
+++ b/README.md
@@ -35,36 +35,37 @@ command_bus.register(FooCommand, -> (foo_cmd) { FooService.new(event_store: even
 command_bus.register(BarCommand, -> (bar_cmd) { BarService.new.call(bar_cmd) })
 ```
 
-Alternatively, you can register a Class and it will be instantiated per call, which provides the same behavior as `subscribe` in RailsEventStore.
+Alternatively, you can register a Class and it will be instantiated per call.
 
 ```ruby
 command_bus = Arkency::CommandBus.new
-command_bus.register(FooCommand, -> FooService)
-command_bus.register(BarCommand, -> BarService)
+command_bus.register(FooCommand, FooService)
 ```
+
+If the Class, itself, defines `call`, the Class will continue to be used instead of instantiated.
 
 ### Working with Rails development mode
 
-In Rails `development` mode when you change a registered class, it is reloaded, and a new class with same name is constructed. 
+In Rails `development` mode when you change a registered class, it is reloaded, and a new class with same name is constructed.
 
 ```ruby
 a = User
 a.object_id
-# => 40737760 
+# => 40737760
 
 reload!
 # Reloading...
- 
+
 b = User
 b.object_id
 # => 48425300
 
 h = {a => 1, b => 2}
 h[User]
-# => 2 
+# => 2
 
 a == b
-# => false 
+# => false
 ```
 
 so your `Hash` with mapping from command class to service may not find the new version of reloaded class.
@@ -112,4 +113,3 @@ Why You should attend? Robert has explained this in [this blogpost](http://blog.
 
 Next edition will be held in **September 2017** (Thursday & Friday) in Berlin, Germany.
 Workshop will be held in English.
-

--- a/lib/arkency/command_bus.rb
+++ b/lib/arkency/command_bus.rb
@@ -13,13 +13,18 @@ module Arkency
 
     def register(klass, handler)
       raise MultipleHandlers.new("Multiple handlers not allowed for #{klass}") if handlers[klass]
-      handlers[klass] = handler
+
+      if handler.respond_to?(:call)
+        handlers[klass] = handler
+      else
+        handlers[klass] = -> (command) { handler.new.call(command) }
+      end
     end
 
     def call(command)
-      handler = handlers.fetch(command.class) { raise UnregisteredHandler, "Missing handler for #{command.class}" }
-      handler = handler.new if Class === handler
-      handler.call(command)
+      handlers
+        .fetch(command.class) { raise UnregisteredHandler.new("Missing handler for #{command.class}")  }
+        .(command)
     end
 
     private

--- a/lib/arkency/command_bus.rb
+++ b/lib/arkency/command_bus.rb
@@ -17,9 +17,9 @@ module Arkency
     end
 
     def call(command)
-      handlers
-        .fetch(command.class) { raise UnregisteredHandler.new("Missing handler for #{command.class}")  }
-        .(command)
+      handler = handlers.fetch(command.class) { raise UnregisteredHandler, "Missing handler for #{command.class}" }
+      handler = handler.new if Class === handler
+      handler.call(command)
     end
 
     private


### PR DESCRIPTION
Providing ability to register a Class, which behaves the same as registering a Class with Rails Event Store's `subscribe` method. In our use case we had proliferation of lambda wrapper around Command Bus `register` method so felt patching Command Bus with new instance per call can be beneficial to others.