### PR TITLE
Switch from `thread_safe` to `concurrent-ruby`

### DIFF
--- a/arkency-command_bus.gemspec
+++ b/arkency-command_bus.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "thread_safe"
+  spec.add_dependency "concurrent-ruby"
 
-  spec.add_development_dependency "bundler", "~> 1.10"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.4.0"
 end

--- a/lib/arkency/command_bus.rb
+++ b/lib/arkency/command_bus.rb
@@ -1,5 +1,5 @@
 require 'arkency/command_bus/version'
-require 'thread_safe'
+require 'concurrent/map'
 
 module Arkency
   class CommandBus
@@ -8,7 +8,7 @@ module Arkency
 
     def initialize
       @handlers =
-        ThreadSafe::Cache.new
+        Concurrent::Map.new
     end
 
     def register(klass, handler)


### PR DESCRIPTION
`thread_safe` was deprecated very long time ago. See
https://github.com/ruby-concurrency/thread_safe/

The replacement is `concurrent-ruby` which has many original collection classes from `thread_safe`.